### PR TITLE
Chore/upgrade virtuoso

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 ## Unreleased (2025-04-09)
 - Significant rework of the harvester.
+- Bump virtuoso 
 ### deploy instructions
+Since significant changes, we'll go for a full wipe.
 ```
 drc down
 # make a backup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     restart: always
     logging: *default-logging
   virtuoso:
-    image: redpencil/virtuoso:1.0.0
+    image: redpencil/virtuoso:1.3.0
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/graphs/public"


### PR DESCRIPTION
Bump Virtuoso. See CHANGELOG.md for deployment instructions. If you don't want to lose data, either perform a full dump and restore, or if you're working locally (and can tolerate some data loss), remove the data/db/virtuoso.trx file and restart.