### PR TITLE
expose internal ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
+
 # Unreleased
- - Ensure missing restart directive are set [DL-6508]
- 
+
+- Extract internal ID [CLBV-1054]
+- Ensure missing restart directive are set [DL-6508]
 
 # 1.3.1
 

--- a/config/delta-producer/verenigingen/export.json
+++ b/config/delta-producer/verenigingen/export.json
@@ -213,6 +213,7 @@
       ],
       "properties": [
         "http://mu.semte.ch/vocabularies/core/uuid",
+        "https://data.lblod.info/ns/contactgegevenId",
         "http://www.w3.org/2002/07/owl#sameAs",
         "http://www.w3.org/ns/prov#wasGeneratedBy",
         "http://www.w3.org/2006/vcard/ns#honorific-prefix",
@@ -301,6 +302,7 @@
       ],
       "properties": [
         "http://mu.semte.ch/vocabularies/core/uuid",
+        "https://data.lblod.info/ns/vertegenwoordigerId",
         "http://www.w3.org/ns/org#member",
         "http://schema.org/contactPoint"
       ]
@@ -325,6 +327,7 @@
       ],
       "properties": [
         "http://mu.semte.ch/vocabularies/core/uuid",
+        "https://data.lblod.info/ns/locatieId",
         "https://data.vlaanderen.be/ns/organisatie#bestaatUit",
         "http://purl.org/dc/terms/description",
         "http://data.lblod.info/vocabularies/erediensten/vestigingstype"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,7 @@ services:
     restart: always
     logging: *default-logging
   harvest_scraper:
-    image: lblod/harvesting-verenigingen-scraper-service:2.0.2
+    image: lblod/harvesting-verenigingen-scraper-service:2.0.3
     volumes:
       - ./data/files:/share
       - ./config/harvest_scraper:/config


### PR DESCRIPTION
Expose the internal sequential identifiers for locations, representatives and contactpoints of an organisation.

The property names originate from the datasource.