### PR TITLE
Export: include pav:version, used for ETag

### DIFF
--- a/config/delta-producer/verenigingen/export.json
+++ b/config/delta-producer/verenigingen/export.json
@@ -27,6 +27,7 @@
         "http://www.w3.org/ns/org#hasMembership",
         "http://purl.org/pav/createdOn",
         "http://purl.org/pav/lastUpdateOn",
+        "http://purl.org/pav/version",
         "https://data.lblod.info/ns/bron",
         "https://data.lblod.info/ns/roepnaam",
         "https://data.lblod.info/ns/isUitgeschrevenUitPubliekeDatastroom",


### PR DESCRIPTION
**[CLBV-1046]**

Exposing ETag from the "Vereniging" requests as part of the data on the association. This data is stored in the triplestore and used for version control and making atomic edits to the data in the Verenigingen Loket. The harvester needs to also export this predicate on the associations.

The ETag is stored as a `pav:version` property on the association via JSON LD.

To test: run a harvest and inspect the produced delta files. They should include a `pav:version` on the associations.