### PR TITLE
Feature/job alert service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,20 @@
 # Changelog
 
 # Unreleased
+
 - Bump `lblod/harvesting-verenigingen-import-service` use autocommit for graph move
 - `job-alert-service` creates mails for any failed job
+
+## Deploy notes
+
+Overwrite this configuration in docker-compose.override.yml
+
+```yaml
+  job-alert:
+    environment:
+      EMAIL_FROM: 'noreply@lblod.info'
+      EMAIL_TO: 'noreply@lblod.info'
+```
 
 # 1.5.2
 
@@ -24,16 +36,15 @@ drc up -d harvesting-cleaning
 - import service waits for db to be ready during initialization
 - [CLBV-1084] Include metrics for long running harvest jobs.
 
-
 ## Deploy notes
 
 You might want to change these settings in docker-compose.override.yml:
 
 ```yaml
-  harvest_scraper:
-    environment:
-      PUBLIC_API_BASE_VERENIGINGENREGISTER: "http://publiek.verenigingen.vlaanderen.be" # if harvesting from production
-      FEATURE_SKIP_UNEXPECTED_RESPONSE_FROM_SOURCE: 'true' # change to false to hard fail again on unexpected responses (502s)
+harvest_scraper:
+  environment:
+    PUBLIC_API_BASE_VERENIGINGENREGISTER: 'http://publiek.verenigingen.vlaanderen.be' # if harvesting from production
+    FEATURE_SKIP_UNEXPECTED_RESPONSE_FROM_SOURCE: 'true' # change to false to hard fail again on unexpected responses (502s)
 ```
 
 ```
@@ -47,6 +58,7 @@ drc up -d
 Then, through the frontend, ensure in the scheduled jobs, the harvesjob cron pattern is changed to `30 03 * * *`.
 
 ### About the metrics [CLBV-1084]
+
 You'll have to ping Felix or Niels to wire this into the warning system
 
 # 1.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# Unreleased
+- Bump `lblod/harvesting-verenigingen-import-service` use autocommit for graph move
+- `job-alert-service` creates mails for any failed job
+
 # 1.5.2
 
 - Bump `harvesting-cleanup-previous-jobs-service`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,10 +41,10 @@ drc up -d harvesting-cleaning
 You might want to change these settings in docker-compose.override.yml:
 
 ```yaml
-harvest_scraper:
-  environment:
-    PUBLIC_API_BASE_VERENIGINGENREGISTER: 'http://publiek.verenigingen.vlaanderen.be' # if harvesting from production
-    FEATURE_SKIP_UNEXPECTED_RESPONSE_FROM_SOURCE: 'true' # change to false to hard fail again on unexpected responses (502s)
+  harvest_scraper:
+    environment:
+      PUBLIC_API_BASE_VERENIGINGENREGISTER: 'http://publiek.verenigingen.vlaanderen.be' # if harvesting from production
+      FEATURE_SKIP_UNEXPECTED_RESPONSE_FROM_SOURCE: 'true' # change to false to hard fail again on unexpected responses (502s)
 ```
 
 ```

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -1,117 +1,117 @@
 export default [
   {
     match: {
-      subject: {}
+      subject: {},
     },
     callback: {
       url: 'http://resource/.mu/delta',
-      method: 'POST'
+      method: 'POST',
     },
     options: {
       resourceFormat: 'v0.0.1',
       gracePeriod: 1000,
       ignoreFromSelf: true,
       // foldEffectiveChanges: true // still problems with that
-    }
+    },
   },
   {
     match: {
       predicate: {
         type: 'uri',
-        value: 'http://www.w3.org/ns/adms#status'
+        value: 'http://www.w3.org/ns/adms#status',
       },
       object: {
         type: 'uri',
-        value: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled'
-      }
+        value: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled',
+      },
     },
     callback: {
       method: 'POST',
-      url: 'http://harvest_singleton-job/delta'
+      url: 'http://harvest_singleton-job/delta',
     },
     options: {
       resourceFormat: 'v0.0.1',
       gracePeriod: 1000,
       ignoreFromSelf: true,
       // foldEffectiveChanges: true
-    }
+    },
   },
   {
     match: {
       predicate: {
         type: 'uri',
-        value: 'http://www.w3.org/ns/adms#status'
+        value: 'http://www.w3.org/ns/adms#status',
       },
       object: {
         type: 'uri',
-        value: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled'
-      }
+        value: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled',
+      },
     },
     callback: {
       method: 'POST',
-      url: 'http://harvest_scraper/delta'
+      url: 'http://harvest_scraper/delta',
     },
     options: {
       resourceFormat: 'v0.0.1',
       gracePeriod: 1000,
       ignoreFromSelf: true,
       // foldEffectiveChanges: true
-    }
+    },
   },
   {
     match: {
       predicate: {
         type: 'uri',
-        value: 'http://www.w3.org/ns/adms#status'
+        value: 'http://www.w3.org/ns/adms#status',
       },
       object: {
         type: 'uri',
-        value: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled'
-      }
+        value: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled',
+      },
     },
     callback: {
       method: 'POST',
-      url: 'http://harvest_import/delta'
+      url: 'http://harvest_import/delta',
     },
     options: {
       resourceFormat: 'v0.0.1',
       gracePeriod: 1000,
       ignoreFromSelf: true,
       // foldEffectiveChanges: true
-    }
+    },
   },
   {
     match: {
       predicate: {
         type: 'uri',
-        value: 'http://www.w3.org/ns/adms#status'
-      }
+        value: 'http://www.w3.org/ns/adms#status',
+      },
     },
     callback: {
       method: 'POST',
-      url: 'http://job-controller/delta'
+      url: 'http://job-controller/delta',
     },
     options: {
       resourceFormat: 'v0.0.1',
       gracePeriod: 1000,
       ignoreFromSelf: true,
       // foldEffectiveChanges: true
-    }
+    },
   },
   {
     match: {
       predicate: {
         type: 'uri',
-        value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
+        value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
       },
       object: {
         type: 'uri',
-        value: 'http://vocab.deri.ie/cogs#ScheduledJob'
-      }
+        value: 'http://vocab.deri.ie/cogs#ScheduledJob',
+      },
     },
     callback: {
       method: 'POST',
-      url: 'http://scheduled-job-controller/delta'
+      url: 'http://scheduled-job-controller/delta',
     },
     options: {
       resourceFormat: 'v0.0.1',
@@ -123,144 +123,164 @@ export default [
       gracePeriod: 10000,
       ignoreFromSelf: true,
       // foldEffectiveChanges: true
-    }
+    },
   },
   {
     match: {
       predicate: {
         type: 'uri',
-        value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
+        value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
       },
       object: {
         type: 'uri',
-        value: 'http://redpencil.data.gift/vocabularies/deltas/Error'
-      }
+        value: 'http://redpencil.data.gift/vocabularies/deltas/Error',
+      },
     },
     callback: {
       url: 'http://delta-producer-report-generator/delta',
-      method: 'POST'
+      method: 'POST',
     },
     options: {
       resourceFormat: 'v0.0.1',
       gracePeriod: 1000,
       ignoreFromSelf: true,
       // foldEffectiveChanges: true
-    }
+    },
   },
   {
     match: {
       predicate: {
         type: 'uri',
-        value: 'http://www.w3.org/ns/adms#status'
-      }
+        value: 'http://www.w3.org/ns/adms#status',
+      },
     },
     callback: {
       url: 'http://delta-producer-report-generator/delta',
-      method: 'POST'
+      method: 'POST',
     },
     options: {
       resourceFormat: 'v0.0.1',
       gracePeriod: 1000,
       ignoreFromSelf: true,
       // foldEffectiveChanges: true
-    }
+    },
   },
   {
-    match: {
-    },
+    match: {},
     callback: {
       url: 'http://delta-producer-publication-graph-maintainer/delta',
-      method: 'POST'
+      method: 'POST',
     },
     options: {
       resourceFormat: 'v0.0.1',
       gracePeriod: 1000,
       ignoreFromSelf: true,
       // foldEffectiveChanges: true
-    }
+    },
   },
   {
     match: {
       predicate: {
         type: 'uri',
-        value: 'http://www.w3.org/ns/adms#status'
+        value: 'http://www.w3.org/ns/adms#status',
       },
       object: {
         type: 'uri',
-        value: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled'
-      }
+        value: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled',
+      },
     },
     callback: {
       url: 'http://delta-producer-dump-file-publisher/delta',
-      method: 'POST'
+      method: 'POST',
     },
     options: {
       resourceFormat: 'v0.0.1',
       gracePeriod: 1000,
       ignoreFromSelf: true,
       // foldEffectiveChanges: true
-    }
+    },
   },
   {
     match: {
       predicate: {
         type: 'uri',
-        value: 'http://www.w3.org/ns/adms#status'
+        value: 'http://www.w3.org/ns/adms#status',
       },
       object: {
         type: 'uri',
-        value: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled'
-      }
+        value: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled',
+      },
     },
     callback: {
       method: 'POST',
-      url: 'http://harvesting-cleaning/delta'
+      url: 'http://harvesting-cleaning/delta',
     },
     options: {
       resourceFormat: 'v0.0.1',
       gracePeriod: 1000,
       ignoreFromSelf: true,
       // foldEffectiveChanges: true
-    }
+    },
   },
   {
     match: {
       predicate: {
         type: 'uri',
-        value: 'http://schema.org/repeatFrequency'
-      }
+        value: 'http://schema.org/repeatFrequency',
+      },
     },
     callback: {
       method: 'POST',
-      url: 'http://scheduled-job-controller/delta'
+      url: 'http://scheduled-job-controller/delta',
     },
     options: {
       resourceFormat: 'v0.0.1',
       gracePeriod: 1000,
       ignoreFromSelf: true,
       // foldEffectiveChanges: true
-    }
+    },
   },
   {
     match: {
       predicate: {
         type: 'uri',
-        value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
+        value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
       },
       object: {
         type: 'uri',
-        value: 'http://open-services.net/ns/core#Error'
-      }
+        value: 'http://open-services.net/ns/core#Error',
+      },
     },
     callback: {
       url: 'http://error-alert/delta',
-      method: 'POST'
+      method: 'POST',
     },
     options: {
       resourceFormat: 'v0.0.1',
       gracePeriod: 1000,
       ignoreFromSelf: true,
       // foldEffectiveChanges: true
-    }
-  }
-]
+    },
+  },
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://www.w3.org/ns/adms#status',
+      },
+      object: {
+        type: 'uri',
+        value: 'http://redpencil.data.gift/id/concept/JobStatus/failed',
+      },
+    },
+    callback: {
+      url: 'http://job-alert/delta',
+      method: 'POST',
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 1000,
+      ignoreFromSelf: true,
+    },
+  },
+];

--- a/config/job-alert/config.json
+++ b/config/job-alert/config.json
@@ -1,0 +1,13 @@
+{
+  "creators": [],
+  "email": {
+    "folder": "http://data.lblod.info/id/mail-folders/2"
+  },
+  "graph": {
+    "email": "http://mu.semte.ch/graphs/system/email",
+    "job": "http://mu.semte.ch/graphs/jobs"
+  },
+  "service": {
+    "uri": "http://lblod.data.gift/services/job-alert-service"
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -213,6 +213,17 @@ services:
       - 'logging=true'
     restart: always
     logging: *default-logging
+  
+  job-alert:
+    image: lblod/job-alert-service:latest
+    environment:
+      EMAIL_FROM: 'noreply@lblod.info'
+      EMAIL_TO: 'noreply@lblod.info'
+    volumes:
+      - ./config/job-alert:/config/
+    labels:
+      - "logging=true"
+    restart: always
 
   #############################################################################
   # DELTA GENERAL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,7 +215,7 @@ services:
     logging: *default-logging
   
   job-alert:
-    image: lblod/job-alert-service:latest
+    image: lblod/job-alert-service:0.0.4
     environment:
       EMAIL_FROM: 'noreply@lblod.info'
       EMAIL_TO: 'noreply@lblod.info'


### PR DESCRIPTION
Adds job-alert service which creates emails when jobs fails.

cf https://github.com/lblod/job-alert-service

These commands could be useful to test: 
```
docker compose exec job-alert curl -X POST http://localhost/dry-run
```
or 
```
docker compose exec job-alert curl -X POST http://localhost/create-alerts
```