### PR TITLE
CLBV-1189: Association type changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+# Unreleased
+- Switch to verenigingenregister API v2 [CLBV-1189]
+
+## Deploy notes
+Both app-verenigingen-loket-harvester and app-verenigingen-loket `feature/vzer` (TODO: replace with release tag) need to be deploted together and requires a full harvest to be done, so best to do this after business hours.
+
+- check out app-verenigingen-loket
+- run app-verenigingen-loket migrations
+- `drc up -d` for app-verenigingen-loket-harvester
+- trigger a full harvest (or wait for the scheduled nightly full harvest to run)
+- `drc up -d` for app-verenigingen-loket
+
+
 # 1.7.0
 
 - Bump `lblod/job-alert-service` to 0.0.5: adds per-creator rate limiting to prevent email flooding when jobs fail repeatedly

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,7 +144,7 @@ services:
     restart: always
     logging: *default-logging
   harvest_scraper:
-    image: lblod/harvesting-verenigingen-scraper-service:3.2.0
+    image: lblod/harvesting-verenigingen-scraper-service:4.0.0
     volumes:
       - ./data/files:/share
       - ./config/harvest_scraper:/config
@@ -213,7 +213,7 @@ services:
       - 'logging=true'
     restart: always
     logging: *default-logging
-  
+
   job-alert:
     image: lblod/job-alert-service:0.0.5
     environment:


### PR DESCRIPTION

Both app-verenigingen-loket-harvester and app-verenigingen-loket `feature/vzer` (TODO: replace with release tag) need to be deploted together and requires a full harvest to be done, so best to do this after business hours.

- check out app-verenigingen-loket
- run app-verenigingen-loket migrations
- `drc up -d` for app-verenigingen-loket-harvester
- trigger a full harvest (or wait for the scheduled nightly full harvest to run)
- `drc up -d` for app-verenigingen-loket